### PR TITLE
Fixed PDF extension when uppercase

### DIFF
--- a/javascripts/discourse/initializers/initialize-for-pdf-preview.js
+++ b/javascripts/discourse/initializers/initialize-for-pdf-preview.js
@@ -27,7 +27,7 @@ export default {
             if (!attachments.length) return;
 
             const pdfs = attachments.filter(attachment =>
-              attachment.href.match(/\.[pdf]+$/)
+              attachment.href.match(/\.[pdfPDF]+$/)
             );
 
             if (!pdfs.length) return;


### PR DESCRIPTION
I had a problem with files written with the extension in UPPERCASE. I've tried to use the "i" regex modifier but it didn't work.