### PR TITLE
DEV: take #2 refactor for Safari support

### DIFF
--- a/javascripts/discourse/initializers/initialize-for-pdf-preview.js
+++ b/javascripts/discourse/initializers/initialize-for-pdf-preview.js
@@ -47,10 +47,6 @@ export default {
           if (previewMode === "New Tab") {
             pdf.classList.add("new-tab-pdf");
             pdf.prepend(newTabIcon());
-            pdf.addEventListener("click", (event) => {
-              event.preventDefault();
-              window.open(src);
-            });
           }
 
           return elements;
@@ -95,11 +91,16 @@ export default {
                 if (httpRequest.status === 200) {
                   const src = URL.createObjectURL(httpRequest.response);
 
-                  // update object/iframe data/src for inline previews based on
-                  // xhr response
                   if (previewMode === "Inline") {
                     elements.object.data = src;
                     elements.iframe.src = src;
+                  }
+
+                  if (previewMode === "New Tab") {
+                    pdf.addEventListener("click", (event) => {
+                      event.preventDefault();
+                      window.open(src);
+                    });
                   }
                 }
               };


### PR DESCRIPTION
Most of the changes in this PR are about moving code around. Here are the big changes.

- #2 changed the way this component works to use base64 URLs as the src for the preview iFrame. The issue with this is that browser length limitations for a base64 URL are not standardized. So, this makes it very difficult to assess whether or not the file will be loaded. It would depend on the file size. For example, Chrome caps it at 2mb while Firefox doesn't seem to have any limits. This PR reverts back to using blob object URLs.

- Instead of just loading an iFrame, this PR wraps the iFrame in an `<object>` tag. If the browser supports the object tag, it will load the preview in it. If not, it will load the iFrame. The reason for doing this is mostly about Safari support. 

- In #2 the iFrame wasn't appended until the XHR request had been resolved. This means that it caused jitter as the file got loaded. This PR appends it a little bit earlier and changes the src once the request is ready. That prevents the jitter as the file loads. 