### PR TITLE
UX: adds missing iFrame attributes

### DIFF
--- a/javascripts/discourse/initializers/initialize-for-pdf-preview.js
+++ b/javascripts/discourse/initializers/initialize-for-pdf-preview.js
@@ -31,6 +31,9 @@ export default {
           const iframe = document.createElement("iframe");
           iframe.src = "";
           iframe.type = "application/pdf";
+          iframe.height = PREVIEW_HEIGHT;
+          iframe.loading = "lazy";
+          iframe.classList.add("pdf-preview");
 
           object.append(iframe);
 


### PR DESCRIPTION
This is a follow-up to #3 

It adds some attributes to the iFrame element in case the browser prefers it over the `<object>` tag.