### PR TITLE
FIX: PDF file extension regular expression

### DIFF
--- a/javascripts/discourse/initializers/initialize-for-pdf-preview.js
+++ b/javascripts/discourse/initializers/initialize-for-pdf-preview.js
@@ -52,9 +52,7 @@ export default {
           (post) => {
             const attachments = [...post.querySelectorAll(".attachment")];
 
-            const pdfs = attachments.filter((attachment) =>
-              attachment.href.match(/\.[pdf]+$/)
-            );
+            const pdfs = attachments.filter((attachment) => /\.pdf$/i.test(attachment.href));
 
             pdfs.forEach((pdf) => {
               const fileSize = pdf.nextSibling;

--- a/javascripts/discourse/initializers/initialize-for-pdf-preview.js
+++ b/javascripts/discourse/initializers/initialize-for-pdf-preview.js
@@ -52,7 +52,9 @@ export default {
           (post) => {
             const attachments = [...post.querySelectorAll(".attachment")];
 
-            const pdfs = attachments.filter((attachment) => /\.pdf$/i.test(attachment.href));
+            const pdfs = attachments.filter((attachment) => 
+              /\.pdf$/i.test(attachment.href)
+            );
 
             pdfs.forEach((pdf) => {
               const fileSize = pdf.nextSibling;

--- a/javascripts/discourse/initializers/initialize-for-pdf-preview.js
+++ b/javascripts/discourse/initializers/initialize-for-pdf-preview.js
@@ -52,7 +52,7 @@ export default {
           (post) => {
             const attachments = [...post.querySelectorAll(".attachment")];
 
-            const pdfs = attachments.filter((attachment) => 
+            const pdfs = attachments.filter((attachment) =>
               /\.pdf$/i.test(attachment.href)
             );
 


### PR DESCRIPTION
Fixed the regexp to check the file extension. `[pdf]+$` would match anything ending with at least one of the three letters.

Use the `i` modifier on the regexp to ensure we're case insensitive.

Also use `test` rather than `match` since we only care about whether it matches and not the actual match data.