### PR TITLE
FIX: Add `stopPropagation` to the click event

### DIFF
--- a/javascripts/discourse/initializers/initialize-for-pdf-preview.js
+++ b/javascripts/discourse/initializers/initialize-for-pdf-preview.js
@@ -102,6 +102,7 @@ export default {
                   if (renderMode === "New Tab") {
                     pdf.addEventListener("click", (event) => {
                       event.preventDefault();
+                      event.stopPropagation();
                       window.open(src);
                     });
                   }


### PR DESCRIPTION
The PDF link click event listener lacks a `stopPropagation`, which causes an unnecessary download action to be triggered after opening the PDF preview

This commit adds it back.

Before:
Clicking the PDF link opens both a new tab AND (unhelpfully) a download modal in Chrome

After:
Clicking on a PDF link will only open a new tab preview

Related meta topic: https://meta.discourse.org/t/new-tab-link-opens-both-a-new-tab-and-unhelpfully-a-download-modal-in-chrome/314901